### PR TITLE
Creating JavaSoundAudioDevice based on Mixer.Info

### DIFF
--- a/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
+++ b/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
@@ -113,12 +113,7 @@ public class JavaSoundAudioDevice extends AudioDeviceBase
 		Throwable t = null;
 		try
 		{
-			Line line = null;
-			if(mixer==null) {
-				line = AudioSystem.getLine(getSourceLineInfo());
-			} else {
-				line = AudioSystem.getSourceDataLine(getAudioFormat(), mixer);
-			}
+			Line line = getLine();
 			if (line instanceof SourceDataLine)
 			{
 				source = (SourceDataLine)line;

--- a/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
+++ b/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
@@ -87,6 +87,10 @@ public class JavaSoundAudioDevice extends AudioDeviceBase
 		return info;
 	}
 
+	protected Line getLine() throws LineUnavailableException {
+		return AudioSystem.getLine(getSourceLineInfo());
+	}
+
 	public void open(AudioFormat fmt) throws JavaLayerException
 	{
 		if (!isOpen())

--- a/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
+++ b/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
@@ -113,7 +113,7 @@ public class JavaSoundAudioDevice extends AudioDeviceBase
 			if(mixer==null) {
 				line = AudioSystem.getLine(getSourceLineInfo());
 			} else {
-				line = AudioSystem.getSourceDataLine(fmt, mixer);
+				line = AudioSystem.getSourceDataLine(getAudioFormat(), mixer);
 			}
 			if (line instanceof SourceDataLine)
 			{

--- a/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
+++ b/jlayer/src/javazoom/jl/player/JavaSoundAudioDevice.java
@@ -30,7 +30,6 @@ import javax.sound.sampled.DataLine;
 import javax.sound.sampled.Line;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
-import javax.sound.sampled.Mixer;
 
 import javazoom.jl.decoder.Decoder;
 import javazoom.jl.decoder.JavaLayerException;
@@ -49,16 +48,6 @@ public class JavaSoundAudioDevice extends AudioDeviceBase
 	private AudioFormat		fmt = null;
 
 	private byte[]			byteBuf = new byte[4096];
-
-	private Mixer.Info		mixer = null;
-
-	public JavaSoundAudioDevice() {
-
-	}
-
-	public JavaSoundAudioDevice(Mixer.Info mixer0) {
-		mixer = mixer0;
-	}
 
 	protected void setAudioFormat(AudioFormat fmt0)
 	{


### PR DESCRIPTION
This gives the ability to create your Audio Device by specifying a specific mixer and passing in the Mixer.Info in the constructor. If not passed, old functionality is used. 