### PR TITLE
Add support for OSGi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+*.iml
+.idea

--- a/jlayer/pom.xml
+++ b/jlayer/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>jlayer</artifactId>
     <version>1.0.1-2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>JLayer</name>
     <description>Maven artifact for JLayer library. http://www.javazoom.net/javalayer/sources.html</description>
     <developers>

--- a/jorbis/pom.xml
+++ b/jorbis/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>jorbis</artifactId>
     <version>0.0.17-3-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>JOrbis</name>
     <description>Maven artifact for JOrbis library. http://www.jcraft.com/jorbis/</description>
     <developers>

--- a/mp3spi/pom.xml
+++ b/mp3spi/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>mp3spi</artifactId>
     <version>1.9.5-2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>MP3SPI</name>
     <description>Maven artifact for MP3SPI library. http://www.javazoom.net/mp3spi/mp3spi.html</description>
     <developers>

--- a/mp3spi/pom.xml
+++ b/mp3spi/pom.xml
@@ -42,6 +42,18 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <SPI-Provider>javax.sound.sampled.AudioSystem</SPI-Provider>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,13 @@
                         </links>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <inherited>true</inherited>
+                    <extensions>true</extensions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -90,6 +97,10 @@
                     <pushChanges>false</pushChanges>
                     <localCheckout>true</localCheckout>
                 </configuration>                       
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
             </plugin>
             
         </plugins>

--- a/tritonus-all/pom.xml
+++ b/tritonus-all/pom.xml
@@ -7,6 +7,7 @@
         <version>1.3-SNAPSHOT</version>
     </parent>
     <artifactId>tritonus-all</artifactId>
+    <packaging>bundle</packaging>
     <version>0.3.7-1-SNAPSHOT</version>
     <name>tritonus-all</name>
     <description>Complete tritonus package with all plugins</description>

--- a/tritonus-cvs/src/classes/org/tritonus/core/Service.java
+++ b/tritonus-cvs/src/classes/org/tritonus/core/Service.java
@@ -135,7 +135,12 @@ public class Service
 		Enumeration	configs = null;
 		try
 		{
-			configs = ClassLoader.getSystemResources(strFullName);
+			ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+			if (ccl != null) {
+				configs = ccl.getResources(strFullName);
+			} else {
+				configs = ClassLoader.getSystemResources(strFullName);
+			}
 		}
 		catch (IOException e)
 		{

--- a/tritonus-share/pom.xml
+++ b/tritonus-share/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>tritonus-share</artifactId>
     <version>0.3.7-3-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>tritonus-share</name>
     <description>Maven artifact for tritonus-share library of tritonus.org</description>
     

--- a/vorbisspi/pom.xml
+++ b/vorbisspi/pom.xml
@@ -9,6 +9,7 @@
 
     <artifactId>vorbisspi</artifactId>
     <version>1.0.3-2-SNAPSHOT</version>
+    <packaging>bundle</packaging>
     <name>VorbisSPI</name>
     <description>Maven artifact for VorbisSPI library. http://www.javazoom.net/vorbisspi/vorbisspi.html</description>
     <developers>

--- a/vorbisspi/pom.xml
+++ b/vorbisspi/pom.xml
@@ -35,6 +35,18 @@
                 <filtering>false</filtering>
             </resource>
         </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <SPI-Provider>javax.sound.sampled.AudioSystem</SPI-Provider>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>


### PR DESCRIPTION
I would like to use the sound libraries in an OSGi environment. With the current version, this is not possible because the artifacts produced by the build do not contain OSGi meta data. This patch adds the required meta data by using the maven-bundle-plugin.

Using JavaSound in OSGi is a bit tricky because behind the scenes a variant of the Java service loader mechanism is used which is not directly compatible with the way classloading is handled by the OSGi framework. Therefore, I used Apache Aries SPI Fly (http://aries.apache.org/modules/spi-fly.html) to make this work. This basically boils down to adding a special header to the manifests of bundles that provide services for this service loader mechanism (the spi bundles for mp3 and ogg in this case).

It was also necessary to tweak org.tritonus.core.Service to use the TCCL rather than the system classloader (if possible). I think the way Service was implemented is problematic as it prevents the usage of this library in any environment with a more complex classloader setup. The implementation proposed by this patch is much closer to the way dynamic service loading is handled by the JavaSound implementation shipped with the JDK.

The changes made by this patch should not affect the functionality of the library when used in a stand-alone environment. The major part is just additional entries in the jar manifests not interpreted by a stand-alone Jave application. Also the changing of the service loading did not have any undesired effects in my tests.