### PR TITLE
#5 Add module BasicPlayer.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,8 @@ Following artifacts are released including source and javadoc artifacts:
   * http://www.javazoom.net/javalayer/javalayer.html[JLayer] - MP3 decoder and  encoder 
   * http://www.javazoom.net/mp3spi/mp3spi.html[MP3SPI] - javax.sound provider for MP3 decoding and encoding based on JLayer
   * http://www.jcraft.com/jorbis/[JOrbis] - OGG Vorbis decoder and encoder
-  * http://www.javazoom.net/vorbisspi/vorbisspi.html[VorbisSPI] Service provider for decoding OGG Vorbis
+  * http://www.javazoom.net/vorbisspi/vorbisspi.html[VorbisSPI] - Service provider for decoding OGG Vorbis
+  * http://www.javazoom.net/jlgui/api.html[BasicPlayer] - BasicPlayer layer is the simple player API of jlGui. These classes are designed to be used in any application that needs simple features (play, stop, pause, resume, seek) to play audio file or stream. It's a high-level API over JavaSound API.
 
 == How to use
 
@@ -50,9 +51,20 @@ Add any of these dependencies to your project:
   <artifactId>vorbisspi</artifactId>
   <version>1.0.3-2</version>
 </dependency>
+
+<dependency>
+  <groupId>com.googlecode.soundlibs</groupId>
+  <artifactId>basicplayer</artifactId>
+  <version>3.0.0-1</version>
+</dependency>
 ----
 
 == Changes
+
+=== soundlibs 1.4
+
+* Added BasicPlayer module
+* mp3spi exports javazoom.spi package
 
 === soundlibs 1.3
 

--- a/basicplayer/LICENSE.txt
+++ b/basicplayer/LICENSE.txt
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/basicplayer/README.txt
+++ b/basicplayer/README.txt
@@ -1,0 +1,42 @@
+---------------------------------------------------------
+ jlGui : JAVA music player for Java platform.
+
+ Project Homepage :
+   http://www.javazoom.net/jlgui/jlgui.html
+
+ MP3 & JAVA Forums :
+   http://www.javazoom.net/services/forums/index.jsp
+
+ JNLP (JavaWebStart) configurator :
+   http://www.javazoom.net/jlgui/jnlp_configurator.jsp
+---------------------------------------------------------
+
+11/14/2006 : 3.0
+----------------
+- JavaSound mixer selector added.
+- "basicplayer.sourcedataline" property added.
+- Skip bug fix.
++ J2SE 1.6.0 RC
+
+
+04/05/2004 : jlGui - BasicPlayer 2.3
+------------------------------------
+- Seek feature added.
+
+- BasicPlayer redesigned :
+  + BasicPlayerEvent added.
+  + Threaded events
+  + Audio properties.
+
+- Bug fixes :
+  + 8 bits WAV file support added.
+
+- Tested JavaSound SPI :
+  + VorbisSPI 1.0 (JavaZOOM).
+  + MP3SPI 1.9 (JavaZOOM).
+  + WAV, AU, AIFF (SUN)
+
+- Tested J2SE :
+  + J2SE 1.3.1
+  + J2SE 1.4.2
+  + J2SE 1.5.0 beta

--- a/basicplayer/pom.xml
+++ b/basicplayer/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>soundlibs</artifactId>
+    <groupId>com.googlecode.soundlibs</groupId>
+    <version>1.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>basicplayer</artifactId>
+  <version>3.0.0-1-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+  <name>BasicPlayer</name>
+  <description>Maven artifact for BasicPlayer API. http://www.javazoom.net/jlgui/api.html</description>
+  <developers>
+    <developer>
+      <name>JavaZoom</name>
+      <email>jlgui@javazoom.net</email>
+      <organizationUrl>http://www.javazoom.net/jlgui/jlgui.html</organizationUrl>
+      <roles>
+        <role>Original Author</role>
+      </roles>
+      <url>http://www.javazoom.net/jlgui/api.html</url>
+    </developer>
+    <developer>
+      <name>Elliot Huntington</name>
+      <email>elliot.huntington@gmail.com</email>
+      <roles>
+        <role>Packager</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.googlecode.soundlibs</groupId>
+      <artifactId>mp3spi</artifactId>
+      <version>1.9.5-3-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.soundlibs</groupId>
+      <artifactId>tritonus-share</artifactId>
+      <version>0.3.7-3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.12</version>
+    </dependency>
+
+  </dependencies>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/basicplayer/pom.xml
+++ b/basicplayer/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.googlecode.soundlibs</groupId>
       <artifactId>tritonus-share</artifactId>
-      <version>0.3.7-3</version>
+      <version>0.3.7-4-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicController.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicController.java
@@ -1,0 +1,102 @@
+/*
+ * BasicController.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * This interface defines player controls available.  
+ */
+public interface BasicController
+{
+    /**
+     * Open inputstream to play.
+     * @param in
+     * @throws BasicPlayerException
+     */
+    public void open(InputStream in) throws BasicPlayerException;
+
+    /**
+     * Open file to play.
+     * @param file
+     * @throws BasicPlayerException
+     */
+    public void open(File file) throws BasicPlayerException;
+
+    /**
+     * Open URL to play.
+     * @param url
+     * @throws BasicPlayerException
+     */
+    public void open(URL url) throws BasicPlayerException;
+
+    /**
+     * Skip bytes.
+     * @param bytes
+     * @return bytes skipped according to audio frames constraint.
+     * @throws BasicPlayerException
+     */
+    public long seek(long bytes) throws BasicPlayerException;
+
+    /**
+     * Start playback.
+     * @throws BasicPlayerException
+     */
+    public void play() throws BasicPlayerException;
+
+    /**
+     * Stop playback. 
+     * @throws BasicPlayerException
+     */
+    public void stop() throws BasicPlayerException;
+
+    /**
+     * Pause playback. 
+     * @throws BasicPlayerException
+     */
+    public void pause() throws BasicPlayerException;
+
+    /**
+     * Resume playback. 
+     * @throws BasicPlayerException
+     */
+    public void resume() throws BasicPlayerException;
+
+    /**
+     * Sets Pan (Balance) value.
+     * Linear scale : -1.0 <--> +1.0
+     * @param pan value from -1.0 to +1.0
+     * @throws BasicPlayerException
+     */
+    public void setPan(double pan) throws BasicPlayerException;
+
+    /**
+     * Sets Gain value.
+     * Linear scale 0.0  <-->  1.0
+     * @param gain value from 0.0 to 1.0
+     * @throws BasicPlayerException
+     */
+    public void setGain(double gain) throws BasicPlayerException;
+}

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayer.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayer.java
@@ -1,0 +1,1038 @@
+/*
+ * BasicPlayer.
+ *
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Control;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.FloatControl;
+import javax.sound.sampled.Line;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
+import javax.sound.sampled.SourceDataLine;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import javazoom.spi.PropertiesContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tritonus.share.sampled.TAudioFormat;
+import org.tritonus.share.sampled.file.TAudioFileFormat;
+
+/**
+ * BasicPlayer is a threaded simple player class based on JavaSound API.
+ * It has been successfully tested under J2SE 1.3.x, 1.4.x and 1.5.x.
+ */
+public class BasicPlayer implements BasicController, Runnable
+{
+    public static int EXTERNAL_BUFFER_SIZE = 4000 * 4;
+    public static int SKIP_INACCURACY_SIZE = 1200;
+    protected Thread m_thread = null;
+    protected Object m_dataSource;
+    protected AudioInputStream m_encodedaudioInputStream;
+    protected int encodedLength = -1;
+    protected AudioInputStream m_audioInputStream;
+    protected AudioFileFormat m_audioFileFormat;
+    protected SourceDataLine m_line;
+    protected FloatControl m_gainControl;
+    protected FloatControl m_panControl;
+    protected String m_mixerName = null;
+    private int m_lineCurrentBufferSize = -1;
+    private int lineBufferSize = -1;
+    private long threadSleep = -1;
+    private static Logger log = LoggerFactory.getLogger(BasicPlayer.class);
+    /**
+     * These variables are used to distinguish stopped, paused, playing states.
+     * We need them to control Thread.
+     */
+    public static final int UNKNOWN = -1;
+    public static final int PLAYING = 0;
+    public static final int PAUSED = 1;
+    public static final int STOPPED = 2;
+    public static final int OPENED = 3;
+    public static final int SEEKING = 4;
+    private int m_status = UNKNOWN;
+    // Listeners to be notified.
+    private Collection m_listeners = null;
+    private Map empty_map = new HashMap();
+
+    /**
+     * Constructs a Basic Player.
+     */
+    public BasicPlayer()
+    {
+        m_dataSource = null;
+        m_listeners = new ArrayList();
+        reset();
+    }
+
+    protected void reset()
+    {
+        m_status = UNKNOWN;
+        if (m_audioInputStream != null)
+        {
+            synchronized (m_audioInputStream)
+            {
+                closeStream();
+            }
+        }
+        m_audioInputStream = null;
+        m_audioFileFormat = null;
+        m_encodedaudioInputStream = null;
+        encodedLength = -1;
+        if (m_line != null)
+        {
+            m_line.stop();
+            m_line.close();
+            m_line = null;
+        }
+        m_gainControl = null;
+        m_panControl = null;
+    }
+
+    /**
+     * Add listener to be notified.
+     * @param bpl
+     */
+    public void addBasicPlayerListener(BasicPlayerListener bpl)
+    {
+        m_listeners.add(bpl);
+    }
+
+    /**
+     * Return registered listeners.
+     * @return
+     */
+    public Collection getListeners()
+    {
+        return m_listeners;
+    }
+
+    /**
+     * Remove registered listener.
+     * @param bpl
+     */
+    public void removeBasicPlayerListener(BasicPlayerListener bpl)
+    {
+        if (m_listeners != null)
+        {
+            m_listeners.remove(bpl);
+        }
+    }
+
+    /**
+     * Set SourceDataLine buffer size. It affects audio latency.
+     * (the delay between line.write(data) and real sound).
+     * Minimum value should be over 10000 bytes.
+     * @param size -1 means maximum buffer size available.
+     */
+    public void setLineBufferSize(int size)
+    {
+        lineBufferSize = size;
+    }
+
+    /**
+     * Return SourceDataLine buffer size.
+     * @return -1 maximum buffer size.
+     */
+    public int getLineBufferSize()
+    {
+        return lineBufferSize;
+    }
+    
+    /**
+     * Return SourceDataLine current buffer size.
+     * @return
+     */
+    public int getLineCurrentBufferSize()
+    {
+        return m_lineCurrentBufferSize;
+    }
+
+    /**
+     * Set thread sleep time.
+     * Default is -1 (no sleep time).
+     * @param time in milliseconds.
+     */
+    public void setSleepTime(long time)
+    {
+        threadSleep = time;
+    }
+
+    /**
+     * Return thread sleep time in milliseconds.
+     * @return -1 means no sleep time.
+     */
+    public long getSleepTime()
+    {
+        return threadSleep;
+    }
+
+    /**
+     * Returns BasicPlayer status.
+     * @return status
+     */
+    public int getStatus()
+    {
+        return m_status;
+    }
+
+    /**
+     * Open file to play.
+     */
+    public void open(File file) throws BasicPlayerException
+    {
+        log.info("open(" + file + ")");
+        if (file != null)
+        {
+            m_dataSource = file;
+            initAudioInputStream();
+        }
+    }
+
+    /**
+     * Open URL to play.
+     */
+    public void open(URL url) throws BasicPlayerException
+    {
+        log.info("open(" + url + ")");
+        if (url != null)
+        {
+            m_dataSource = url;
+            initAudioInputStream();
+        }
+    }
+
+    /**
+     * Open inputstream to play.
+     */
+    public void open(InputStream inputStream) throws BasicPlayerException
+    {
+        log.info("open(" + inputStream + ")");
+        if (inputStream != null)
+        {
+            m_dataSource = inputStream;
+            initAudioInputStream();
+        }
+    }
+
+    /**
+     * Inits AudioInputStream and AudioFileFormat from the data source.
+     * @throws BasicPlayerException
+     */
+    protected void initAudioInputStream() throws BasicPlayerException
+    {
+        try
+        {
+            reset();
+            notifyEvent(BasicPlayerEvent.OPENING, getEncodedStreamPosition(), -1, m_dataSource);
+            if (m_dataSource instanceof URL)
+            {
+                initAudioInputStream((URL) m_dataSource);
+            }
+            else if (m_dataSource instanceof File)
+            {
+                initAudioInputStream((File) m_dataSource);
+            }
+            else if (m_dataSource instanceof InputStream)
+            {
+                initAudioInputStream((InputStream) m_dataSource);
+            }
+            createLine();
+            // Notify listeners with AudioFileFormat properties.
+            Map properties = null;
+            if (m_audioFileFormat instanceof TAudioFileFormat)
+            {
+                // Tritonus SPI compliant audio file format.
+                properties = ((TAudioFileFormat) m_audioFileFormat).properties();
+                // Clone the Map because it is not mutable.
+                properties = deepCopy(properties);
+            }
+            else properties = new HashMap();
+            // Add JavaSound properties.
+            if (m_audioFileFormat.getByteLength() > 0) properties.put("audio.length.bytes", new Integer(m_audioFileFormat.getByteLength()));
+            if (m_audioFileFormat.getFrameLength() > 0) properties.put("audio.length.frames", new Integer(m_audioFileFormat.getFrameLength()));
+            if (m_audioFileFormat.getType() != null) properties.put("audio.type", (m_audioFileFormat.getType().toString()));
+            // Audio format.
+            AudioFormat audioFormat = m_audioFileFormat.getFormat();
+            if (audioFormat.getFrameRate() > 0) properties.put("audio.framerate.fps", new Float(audioFormat.getFrameRate()));
+            if (audioFormat.getFrameSize() > 0) properties.put("audio.framesize.bytes", new Integer(audioFormat.getFrameSize()));
+            if (audioFormat.getSampleRate() > 0) properties.put("audio.samplerate.hz", new Float(audioFormat.getSampleRate()));
+            if (audioFormat.getSampleSizeInBits() > 0) properties.put("audio.samplesize.bits", new Integer(audioFormat.getSampleSizeInBits()));
+            if (audioFormat.getChannels() > 0) properties.put("audio.channels", new Integer(audioFormat.getChannels()));
+            if (audioFormat instanceof TAudioFormat)
+            {
+                // Tritonus SPI compliant audio format.
+                Map addproperties = ((TAudioFormat) audioFormat).properties();
+                properties.putAll(addproperties);
+            }
+            // Add SourceDataLine
+            properties.put("basicplayer.sourcedataline", m_line);
+            Iterator it = m_listeners.iterator();
+            while (it.hasNext())
+            {
+                BasicPlayerListener bpl = (BasicPlayerListener) it.next();
+                bpl.opened(m_dataSource, properties);
+            }
+            m_status = OPENED;
+            notifyEvent(BasicPlayerEvent.OPENED, getEncodedStreamPosition(), -1, null);
+        }
+        catch (LineUnavailableException e)
+        {
+            throw new BasicPlayerException(e);
+        }
+        catch (UnsupportedAudioFileException e)
+        {
+            throw new BasicPlayerException(e);
+        }
+        catch (IOException e)
+        {
+            throw new BasicPlayerException(e);
+        }
+    }
+
+    /**
+     * Inits Audio ressources from file.
+     */
+    protected void initAudioInputStream(File file) throws UnsupportedAudioFileException, IOException
+    {
+        m_audioInputStream = AudioSystem.getAudioInputStream(file);
+        m_audioFileFormat = AudioSystem.getAudioFileFormat(file);
+    }
+
+    /**
+     * Inits Audio ressources from URL.
+     */
+    protected void initAudioInputStream(URL url) throws UnsupportedAudioFileException, IOException
+    {
+        m_audioInputStream = AudioSystem.getAudioInputStream(url);
+        m_audioFileFormat = AudioSystem.getAudioFileFormat(url);
+    }
+
+    /**
+     * Inits Audio ressources from InputStream.
+     */
+    protected void initAudioInputStream(InputStream inputStream) throws UnsupportedAudioFileException, IOException
+    {
+        m_audioInputStream = AudioSystem.getAudioInputStream(inputStream);
+        m_audioFileFormat = AudioSystem.getAudioFileFormat(inputStream);
+    }
+
+    /**
+     * Inits Audio ressources from AudioSystem.<br>
+     */
+    protected void initLine() throws LineUnavailableException
+    {
+        log.info("initLine()");
+        if (m_line == null) createLine();
+        if (!m_line.isOpen())
+        {
+            openLine();
+        }
+        else
+        {
+            AudioFormat lineAudioFormat = m_line.getFormat();
+            AudioFormat audioInputStreamFormat = m_audioInputStream == null ? null : m_audioInputStream.getFormat();
+            if (!lineAudioFormat.equals(audioInputStreamFormat))
+            {
+                m_line.close();
+                openLine();
+            }
+        }
+    }
+
+    /**
+     * Inits a DateLine.<br>
+     *
+     * We check if the line supports Gain and Pan controls.
+     *
+     * From the AudioInputStream, i.e. from the sound file, we
+     * fetch information about the format of the audio data. These
+     * information include the sampling frequency, the number of
+     * channels and the size of the samples. There information
+     * are needed to ask JavaSound for a suitable output line
+     * for this audio file.
+     * Furthermore, we have to give JavaSound a hint about how
+     * big the internal buffer for the line should be. Here,
+     * we say AudioSystem.NOT_SPECIFIED, signaling that we don't
+     * care about the exact size. JavaSound will use some default
+     * value for the buffer size.
+     */
+    protected void createLine() throws LineUnavailableException
+    {
+        log.info("Create Line");
+        if (m_line == null)
+        {
+            AudioFormat sourceFormat = m_audioInputStream.getFormat();
+            log.info("Create Line : Source format : " + sourceFormat.toString());
+            int nSampleSizeInBits = sourceFormat.getSampleSizeInBits();
+            if (nSampleSizeInBits <= 0) nSampleSizeInBits = 16;
+            if ((sourceFormat.getEncoding() == AudioFormat.Encoding.ULAW) || (sourceFormat.getEncoding() == AudioFormat.Encoding.ALAW)) nSampleSizeInBits = 16;
+            if (nSampleSizeInBits != 8) nSampleSizeInBits = 16;
+            AudioFormat targetFormat = new AudioFormat(AudioFormat.Encoding.PCM_SIGNED, sourceFormat.getSampleRate(), nSampleSizeInBits, sourceFormat.getChannels(), sourceFormat.getChannels() * (nSampleSizeInBits / 8), sourceFormat.getSampleRate(), false);
+            log.info("Create Line : Target format: " + targetFormat);
+            // Keep a reference on encoded stream to progress notification.
+            m_encodedaudioInputStream = m_audioInputStream;
+            try
+            {
+                // Get total length in bytes of the encoded stream.
+                encodedLength = m_encodedaudioInputStream.available();
+            }
+            catch (IOException e)
+            {
+                log.error("Cannot get m_encodedaudioInputStream.available()", e);
+            }
+            // Create decoded stream.
+            m_audioInputStream = AudioSystem.getAudioInputStream(targetFormat, m_audioInputStream);
+            AudioFormat audioFormat = m_audioInputStream.getFormat();
+            DataLine.Info info = new DataLine.Info(SourceDataLine.class, audioFormat, AudioSystem.NOT_SPECIFIED);
+            Mixer mixer = getMixer(m_mixerName);
+            if (mixer != null)
+            {
+                log.info("Mixer : "+mixer.getMixerInfo().toString());
+                m_line = (SourceDataLine) mixer.getLine(info);
+            }
+            else 
+            {
+                m_line = (SourceDataLine) AudioSystem.getLine(info);
+                m_mixerName = null;
+            }
+            log.info("Line : " + m_line.toString());
+            log.debug("Line Info : " + m_line.getLineInfo().toString());
+            log.debug("Line AudioFormat: " + m_line.getFormat().toString());
+        }
+    }
+
+    /**
+     * Opens the line.
+     */
+    protected void openLine() throws LineUnavailableException
+    {
+        if (m_line != null)
+        {
+            AudioFormat audioFormat = m_audioInputStream.getFormat();
+            int buffersize = lineBufferSize;
+            if (buffersize <= 0) buffersize = m_line.getBufferSize();
+            m_lineCurrentBufferSize = buffersize;
+            m_line.open(audioFormat, buffersize);
+            log.info("Open Line : BufferSize=" + buffersize);
+            /*-- Display supported controls --*/
+            Control[] c = m_line.getControls();
+            for (int p = 0; p < c.length; p++)
+            {
+                log.debug("Controls : " + c[p].toString());
+            }
+            /*-- Is Gain Control supported ? --*/
+            if (m_line.isControlSupported(FloatControl.Type.MASTER_GAIN))
+            {
+                m_gainControl = (FloatControl) m_line.getControl(FloatControl.Type.MASTER_GAIN);
+                log.info("Master Gain Control : [" + m_gainControl.getMinimum() + "," + m_gainControl.getMaximum() + "] " + m_gainControl.getPrecision());
+            }
+            /*-- Is Pan control supported ? --*/
+            if (m_line.isControlSupported(FloatControl.Type.PAN))
+            {
+                m_panControl = (FloatControl) m_line.getControl(FloatControl.Type.PAN);
+                log.info("Pan Control : [" + m_panControl.getMinimum() + "," + m_panControl.getMaximum() + "] " + m_panControl.getPrecision());
+            }
+        }
+    }
+
+    /**
+     * Stops the playback.<br>
+     *
+     * Player Status = STOPPED.<br>
+     * Thread should free Audio ressources.
+     */
+    protected void stopPlayback()
+    {
+        if ((m_status == PLAYING) || (m_status == PAUSED))
+        {
+            if (m_line != null)
+            {
+                m_line.flush();
+                m_line.stop();
+            }
+            m_status = STOPPED;
+            notifyEvent(BasicPlayerEvent.STOPPED, getEncodedStreamPosition(), -1, null);
+            synchronized (m_audioInputStream)
+            {
+                closeStream();
+            }
+            log.info("stopPlayback() completed");
+        }
+    }
+
+    /**
+     * Pauses the playback.<br>
+     *
+     * Player Status = PAUSED.
+     */
+    protected void pausePlayback()
+    {
+        if (m_line != null)
+        {
+            if (m_status == PLAYING)
+            {
+                m_line.flush();
+                m_line.stop();
+                m_status = PAUSED;
+                log.info("pausePlayback() completed");
+                notifyEvent(BasicPlayerEvent.PAUSED, getEncodedStreamPosition(), -1, null);
+            }
+        }
+    }
+
+    /**
+     * Resumes the playback.<br>
+     *
+     * Player Status = PLAYING.
+     */
+    protected void resumePlayback()
+    {
+        if (m_line != null)
+        {
+            if (m_status == PAUSED)
+            {
+                m_line.start();
+                m_status = PLAYING;
+                log.info("resumePlayback() completed");
+                notifyEvent(BasicPlayerEvent.RESUMED, getEncodedStreamPosition(), -1, null);
+            }
+        }
+    }
+
+    /**
+     * Starts playback.
+     */
+    protected void startPlayback() throws BasicPlayerException
+    {
+        if (m_status == STOPPED) initAudioInputStream();
+        if (m_status == OPENED)
+        {
+            log.info("startPlayback called");
+            if (!(m_thread == null || !m_thread.isAlive()))
+            {
+                log.info("WARNING: old thread still running!!");
+                int cnt = 0;
+                while (m_status != OPENED)
+                {
+                    try
+                    {
+                        if (m_thread != null)
+                        {
+                            log.info("Waiting ... " + cnt);
+                            cnt++;
+                            Thread.sleep(1000);
+                            if (cnt > 2)
+                            {
+                                m_thread.interrupt();
+                            }
+                        }
+                    }
+                    catch (InterruptedException e)
+                    {
+                        throw new BasicPlayerException(BasicPlayerException.WAITERROR, e);
+                    }
+                }
+            }
+            // Open SourceDataLine.
+            try
+            {
+                initLine();
+            }
+            catch (LineUnavailableException e)
+            {
+                throw new BasicPlayerException(BasicPlayerException.CANNOTINITLINE, e);
+            }
+            log.info("Creating new thread");
+            m_thread = new Thread(this, "BasicPlayer");
+            m_thread.start();
+            if (m_line != null)
+            {
+                m_line.start();
+                m_status = PLAYING;
+                notifyEvent(BasicPlayerEvent.PLAYING, getEncodedStreamPosition(), -1, null);
+            }
+        }
+    }
+
+    /**
+     * Main loop.
+     *
+     * Player Status == STOPPED || SEEKING => End of Thread + Freeing Audio Ressources.<br>
+     * Player Status == PLAYING => Audio stream data sent to Audio line.<br>
+     * Player Status == PAUSED => Waiting for another status.
+     */
+    public void run()
+    {
+        log.info("Thread Running");
+        int nBytesRead = 1;
+        byte[] abData = new byte[EXTERNAL_BUFFER_SIZE];
+        // Lock stream while playing.
+        synchronized (m_audioInputStream)
+        {
+            // Main play/pause loop.
+            while ((nBytesRead != -1) && (m_status != STOPPED) && (m_status != SEEKING) && (m_status != UNKNOWN))
+            {
+                if (m_status == PLAYING)
+                {
+                    // Play.
+                    try
+                    {
+                        nBytesRead = m_audioInputStream.read(abData, 0, abData.length);
+                        if (nBytesRead >= 0)
+                        {
+                            byte[] pcm = new byte[nBytesRead];
+                            System.arraycopy(abData, 0, pcm, 0, nBytesRead);
+                            if (m_line.available() >= m_line.getBufferSize()) log.debug("Underrun : "+m_line.available()+"/"+m_line.getBufferSize());
+                            int nBytesWritten = m_line.write(abData, 0, nBytesRead);
+                            // Compute position in bytes in encoded stream.
+                            int nEncodedBytes = getEncodedStreamPosition();
+                            // Notify listeners
+                            Iterator it = m_listeners.iterator();
+                            while (it.hasNext())
+                            {
+                                BasicPlayerListener bpl = (BasicPlayerListener) it.next();
+                                if (m_audioInputStream instanceof PropertiesContainer)
+                                {
+                                    // Pass audio parameters such as instant bitrate, ...
+                                    Map properties = ((PropertiesContainer) m_audioInputStream).properties();
+                                    bpl.progress(nEncodedBytes, m_line.getMicrosecondPosition(), pcm, properties);
+                                }
+                                else bpl.progress(nEncodedBytes, m_line.getMicrosecondPosition(), pcm, empty_map);
+                            }
+                        }
+                    }
+                    catch (IOException e)
+                    {
+                        log.error("Thread cannot run()", e);
+                        m_status = STOPPED;
+                        notifyEvent(BasicPlayerEvent.STOPPED, getEncodedStreamPosition(), -1, null);
+                    }
+                    // Nice CPU usage.
+                    if (threadSleep > 0)
+                    {
+                        try
+                        {
+                            Thread.sleep(threadSleep);
+                        }
+                        catch (InterruptedException e)
+                        {
+                            log.error("Thread cannot sleep(" + threadSleep + ")", e);
+                        }
+                    }
+                }
+                else
+                {
+                    // Pause
+                    try
+                    {
+                        Thread.sleep(1000);
+                    }
+                    catch (InterruptedException e)
+                    {
+                        log.error("Thread cannot sleep(1000)", e);
+                    }
+                }
+            }
+            // Free audio resources.
+            if (m_line != null)
+            {
+                m_line.drain();
+                m_line.stop();
+                m_line.close();
+                m_line = null;
+            }
+            // Notification of "End Of Media"
+            if (nBytesRead == -1)
+            {
+                notifyEvent(BasicPlayerEvent.EOM, getEncodedStreamPosition(), -1, null);
+            }
+            // Close stream.
+            closeStream();
+        }
+        m_status = STOPPED;
+        notifyEvent(BasicPlayerEvent.STOPPED, getEncodedStreamPosition(), -1, null);
+        log.info("Thread completed");
+    }
+
+    /**
+     * Skip bytes in the File inputstream.
+     * It will skip N frames matching to bytes, so it will never skip given bytes length exactly.
+     * @param bytes
+     * @return value>0 for File and value=0 for URL and InputStream
+     * @throws BasicPlayerException
+     */
+    protected long skipBytes(long bytes) throws BasicPlayerException
+    {
+        long totalSkipped = 0;
+        if (m_dataSource instanceof File)
+        {
+            log.info("Bytes to skip : " + bytes);
+            int previousStatus = m_status;
+            m_status = SEEKING;
+            long skipped = 0;
+            try
+            {
+                synchronized (m_audioInputStream)
+                {
+                    notifyEvent(BasicPlayerEvent.SEEKING, getEncodedStreamPosition(), -1, null);
+                    initAudioInputStream();
+                    if (m_audioInputStream != null)
+                    {
+                        // Loop until bytes are really skipped.
+                        while (totalSkipped < (bytes - SKIP_INACCURACY_SIZE))
+                        {
+                            skipped = m_audioInputStream.skip(bytes - totalSkipped);
+                            if (skipped == 0) break;
+                            totalSkipped = totalSkipped + skipped;
+                            log.info("Skipped : " + totalSkipped + "/" + bytes);
+                            if (totalSkipped == -1) throw new BasicPlayerException(BasicPlayerException.SKIPNOTSUPPORTED);
+                        }
+                    }
+                }
+                notifyEvent(BasicPlayerEvent.SEEKED, getEncodedStreamPosition(), -1, null);
+                m_status = OPENED;
+                if (previousStatus == PLAYING) startPlayback();
+                else if (previousStatus == PAUSED)
+                {
+                    startPlayback();
+                    pausePlayback();
+                }
+            }
+            catch (IOException e)
+            {
+                throw new BasicPlayerException(e);
+            }
+        }
+        return totalSkipped;
+    }
+
+    /**
+     * Notify listeners about a BasicPlayerEvent.
+     * @param code event code.
+     * @param position in the stream when the event occurs.
+     */
+    protected void notifyEvent(int code, int position, double value, Object description)
+    {
+        BasicPlayerEventLauncher trigger = new BasicPlayerEventLauncher(code, position, value, description, new ArrayList(m_listeners), this);
+        trigger.start();
+    }
+
+    protected int getEncodedStreamPosition()
+    {
+        int nEncodedBytes = -1;
+        if (m_dataSource instanceof File)
+        {
+            try
+            {
+                if (m_encodedaudioInputStream != null)
+                {
+                    nEncodedBytes = encodedLength - m_encodedaudioInputStream.available();
+                }
+            }
+            catch (IOException e)
+            {
+                //log.debug("Cannot get m_encodedaudioInputStream.available()",e);
+            }
+        }
+        return nEncodedBytes;
+    }
+
+    protected void closeStream()
+    {
+        // Close stream.
+        try
+        {
+            if (m_audioInputStream != null)
+            {
+                m_audioInputStream.close();
+                log.info("Stream closed");
+            }
+        }
+        catch (IOException e)
+        {
+            log.info("Cannot close stream", e);
+        }
+    }
+
+    /**
+     * Returns true if Gain control is supported.
+     */
+    public boolean hasGainControl()
+    {
+        if (m_gainControl == null)
+        {
+            // Try to get Gain control again (to support J2SE 1.5)
+            if ( (m_line != null) && (m_line.isControlSupported(FloatControl.Type.MASTER_GAIN))) m_gainControl = (FloatControl) m_line.getControl(FloatControl.Type.MASTER_GAIN);
+        }
+        return m_gainControl != null;
+    }
+
+    /**
+     * Returns Gain value.
+     */
+    public float getGainValue()
+    {
+        if (hasGainControl())
+        {
+            return m_gainControl.getValue();
+        }
+        else
+        {
+            return 0.0F;
+        }
+    }
+
+    /**
+     * Gets max Gain value.
+     */
+    public float getMaximumGain()
+    {
+        if (hasGainControl())
+        {
+            return m_gainControl.getMaximum();
+        }
+        else
+        {
+            return 0.0F;
+        }
+    }
+
+    /**
+     * Gets min Gain value.
+     */
+    public float getMinimumGain()
+    {
+        if (hasGainControl())
+        {
+            return m_gainControl.getMinimum();
+        }
+        else
+        {
+            return 0.0F;
+        }
+    }
+
+    /**
+     * Returns true if Pan control is supported.
+     */
+    public boolean hasPanControl()
+    {
+        if (m_panControl == null)
+        {
+            // Try to get Pan control again (to support J2SE 1.5)
+            if ((m_line != null)&& (m_line.isControlSupported(FloatControl.Type.PAN))) m_panControl = (FloatControl) m_line.getControl(FloatControl.Type.PAN);
+        }
+        return m_panControl != null;
+    }
+
+    /**
+     * Returns Pan precision.
+     */
+    public float getPrecision()
+    {
+        if (hasPanControl())
+        {
+            return m_panControl.getPrecision();
+        }
+        else
+        {
+            return 0.0F;
+        }
+    }
+
+    /**
+     * Returns Pan value.
+     */
+    public float getPan()
+    {
+        if (hasPanControl())
+        {
+            return m_panControl.getValue();
+        }
+        else
+        {
+            return 0.0F;
+        }
+    }
+
+    /**
+     * Deep copy of a Map.
+     * @param src
+     * @return
+     */
+    protected Map deepCopy(Map src)
+    {
+        HashMap map = new HashMap();
+        if (src != null)
+        {
+            Iterator it = src.keySet().iterator();
+            while (it.hasNext())
+            {
+                Object key = it.next();
+                Object value = src.get(key);
+                map.put(key, value);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * @see javazoom.jlgui.basicplayer.BasicController#seek(long)
+     */
+    public long seek(long bytes) throws BasicPlayerException
+    {
+        return skipBytes(bytes);
+    }
+
+    /**
+     * @see javazoom.jlgui.basicplayer.BasicController#play()
+     */
+    public void play() throws BasicPlayerException
+    {
+        startPlayback();
+    }
+
+    /**
+     * @see javazoom.jlgui.basicplayer.BasicController#stop()
+     */
+    public void stop() throws BasicPlayerException
+    {
+        stopPlayback();
+    }
+
+    /**
+     * @see javazoom.jlgui.basicplayer.BasicController#pause()
+     */
+    public void pause() throws BasicPlayerException
+    {
+        pausePlayback();
+    }
+
+    /**
+     * @see javazoom.jlgui.basicplayer.BasicController#resume()
+     */
+    public void resume() throws BasicPlayerException
+    {
+        resumePlayback();
+    }
+
+    /**
+     * Sets Pan value.
+     * Line should be opened before calling this method.
+     * Linear scale : -1.0 <--> +1.0
+     */
+    public void setPan(double fPan) throws BasicPlayerException
+    {
+        if (hasPanControl())
+        {
+            log.debug("Pan : " + fPan);
+            m_panControl.setValue((float) fPan);
+            notifyEvent(BasicPlayerEvent.PAN, getEncodedStreamPosition(), fPan, null);
+        }
+        else throw new BasicPlayerException(BasicPlayerException.PANCONTROLNOTSUPPORTED);
+    }
+
+    /**
+     * Sets Gain value.
+     * Line should be opened before calling this method.
+     * Linear scale 0.0  <-->  1.0
+     * Threshold Coef. : 1/2 to avoid saturation.
+     */
+    public void setGain(double fGain) throws BasicPlayerException
+    {
+        if (hasGainControl())
+        {
+            double minGainDB = getMinimumGain();
+            double ampGainDB = ((10.0f / 20.0f) * getMaximumGain()) - getMinimumGain();
+            double cste = Math.log(10.0) / 20;
+            double valueDB = minGainDB + (1 / cste) * Math.log(1 + (Math.exp(cste * ampGainDB) - 1) * fGain);
+            log.debug("Gain : " + valueDB);
+            m_gainControl.setValue((float) valueDB);
+            notifyEvent(BasicPlayerEvent.GAIN, getEncodedStreamPosition(), fGain, null);
+        }
+        else throw new BasicPlayerException(BasicPlayerException.GAINCONTROLNOTSUPPORTED);
+    }
+    
+    public List getMixers()
+    {
+        ArrayList mixers = new ArrayList();
+        Mixer.Info[] mInfos = AudioSystem.getMixerInfo();
+        if (mInfos != null)
+        {
+            for (int i = 0; i < mInfos.length; i++)
+            {
+                Line.Info lineInfo = new Line.Info(SourceDataLine.class);
+                Mixer mixer = AudioSystem.getMixer(mInfos[i]);
+                if (mixer.isLineSupported(lineInfo))
+                {
+                    mixers.add(mInfos[i].getName());
+                }
+            }            
+        }
+        return mixers;        
+    }
+    
+    public Mixer getMixer(String name)
+    {
+        Mixer mixer = null;
+        if (name != null)
+        {
+            Mixer.Info[] mInfos = AudioSystem.getMixerInfo();
+            if (mInfos != null)
+            {
+                for (int i = 0; i < mInfos.length; i++)
+                {
+                    if (mInfos[i].getName().equals(name))
+                    {
+                        mixer = AudioSystem.getMixer(mInfos[i]);
+                        break;
+                    }
+                }            
+            }            
+        }
+        return mixer;
+    }
+    
+    public String getMixerName()
+    {
+        return m_mixerName;
+    }
+    
+    public void setMixerName(String name)
+    {
+        m_mixerName = name;
+    }
+}

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerEvent.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerEvent.java
@@ -1,0 +1,121 @@
+/*
+ * BasicPlayerEvent.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+/**
+ * This class implements player events. 
+ */
+public class BasicPlayerEvent
+{
+    public static final int UNKNOWN = -1;
+    public static final int OPENING = 0;
+    public static final int OPENED = 1;
+    public static final int PLAYING = 2;
+    public static final int STOPPED = 3;
+    public static final int PAUSED = 4;
+    public static final int RESUMED = 5;
+    public static final int SEEKING = 6;
+    public static final int SEEKED = 7;
+    public static final int EOM = 8;
+    public static final int PAN = 9;
+    public static final int GAIN = 10;
+    private int code = UNKNOWN;
+    private int position = -1;
+    private double value = -1.0;
+    private Object source = null;
+    private Object description = null;
+
+    /**
+     * Constructor
+     * @param source of the event
+     * @param code of the envent
+     * @param position optional stream position
+     * @param value opitional control value
+     * @param desc optional description
+     */
+    public BasicPlayerEvent(Object source, int code, int position, double value, Object desc)
+    {
+        this.value = value;
+        this.position = position;
+        this.source = source;
+        this.code = code;
+        this.description = desc;
+    }
+
+    /**
+     * Return code of the event triggered.
+     * @return
+     */
+    public int getCode()
+    {
+        return code;
+    }
+
+    /**
+     * Return position in the stream when event occured.
+     * @return
+     */
+    public int getPosition()
+    {
+        return position;
+    }
+
+    /**
+     * Return value related to event triggered. 
+     * @return
+     */
+    public double getValue()
+    {
+        return value;
+    }
+
+    /**
+     * Return description.
+     * @return
+     */
+    public Object getDescription()
+    {
+        return description;
+    }
+
+    public Object getSource()
+    {
+        return source;
+    }
+
+    public String toString()
+    {
+        if (code == OPENED) return "OPENED:" + position;
+        else if (code == OPENING) return "OPENING:" + position + ":" + description;
+        else if (code == PLAYING) return "PLAYING:" + position;
+        else if (code == STOPPED) return "STOPPED:" + position;
+        else if (code == PAUSED) return "PAUSED:" + position;
+        else if (code == RESUMED) return "RESUMED:" + position;
+        else if (code == SEEKING) return "SEEKING:" + position;
+        else if (code == SEEKED) return "SEEKED:" + position;
+        else if (code == EOM) return "EOM:" + position;
+        else if (code == PAN) return "PAN:" + value;
+        else if (code == GAIN) return "GAIN:" + value;
+        else return "UNKNOWN:" + position;
+    }
+}

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerEventLauncher.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerEventLauncher.java
@@ -1,0 +1,73 @@
+/*
+ * BasicPlayerEventLauncher.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * This class implements a threaded events launcher.
+ */
+public class BasicPlayerEventLauncher extends Thread
+{
+    private int code = -1;
+    private int position = -1;
+    private double value = 0.0;
+    private Object description = null;
+    private Collection listeners = null;
+    private Object source = null;
+
+    /**
+     * Contructor.
+     * @param code
+     * @param position
+     * @param value
+     * @param description
+     * @param listeners
+     * @param source
+     */
+    public BasicPlayerEventLauncher(int code, int position, double value, Object description, Collection listeners, Object source)
+    {
+        super();
+        this.code = code;
+        this.position = position;
+        this.value = value;
+        this.description = description;
+        this.listeners = listeners;
+        this.source = source;
+    }
+
+    public void run()
+    {
+        if (listeners != null)
+        {
+            Iterator it = listeners.iterator();
+            while (it.hasNext())
+            {
+                BasicPlayerListener bpl = (BasicPlayerListener) it.next();
+                BasicPlayerEvent event = new BasicPlayerEvent(source, code, position, value, description);
+                bpl.stateUpdated(event);
+            }
+        }
+    }
+}

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerException.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerException.java
@@ -1,0 +1,107 @@
+/*
+ * BasicPlayerException.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+/**
+ * This class implements custom exception for basicplayer.
+ */
+public class BasicPlayerException extends Exception
+{
+    public static final String GAINCONTROLNOTSUPPORTED = "Gain control not supported";
+    public static final String PANCONTROLNOTSUPPORTED = "Pan control not supported";
+    public static final String WAITERROR = "Wait error";
+    public static final String CANNOTINITLINE = "Cannot init line";
+    public static final String SKIPNOTSUPPORTED = "Skip not supported";
+    private Throwable cause = null;
+
+    public BasicPlayerException()
+    {
+        super();
+    }
+
+    public BasicPlayerException(String msg)
+    {
+        super(msg);
+    }
+
+    public BasicPlayerException(Throwable cause)
+    {
+        super();
+        this.cause = cause;
+    }
+
+    public BasicPlayerException(String msg, Throwable cause)
+    {
+        super(msg);
+        this.cause = cause;
+    }
+
+    public Throwable getCause()
+    {
+        return cause;
+    }
+
+    /**
+     * Returns the detail message string of this throwable. If it was
+     * created with a null message, returns the following:
+     * (cause==null ? null : cause.toString()).
+     */
+    public String getMessage()
+    {
+        if (super.getMessage() != null)
+        {
+            return super.getMessage();
+        }
+        else if (cause != null)
+        {
+            return cause.toString();
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public void printStackTrace()
+    {
+        printStackTrace(System.err);
+    }
+
+    public void printStackTrace(PrintStream out)
+    {
+        synchronized (out)
+        {
+            PrintWriter pw = new PrintWriter(out, false);
+            printStackTrace(pw);
+            pw.flush();
+        }
+    }
+
+    public void printStackTrace(PrintWriter out)
+    {
+        if (cause != null) cause.printStackTrace(out);
+    }
+}

--- a/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerListener.java
+++ b/basicplayer/src/main/java/javazoom/jlgui/basicplayer/BasicPlayerListener.java
@@ -1,0 +1,72 @@
+/*
+ * BasicPlayerListener.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.util.Map;
+
+/**
+ * This interface defines callbacks methods that will be notified
+ * for all registered BasicPlayerListener of BasicPlayer.
+ */
+public interface BasicPlayerListener
+{
+    /**
+     * Open callback, stream is ready to play.
+     *
+     * properties map includes audio format dependant features such as
+     * bitrate, duration, frequency, channels, number of frames, vbr flag,
+     * id3v2/id3v1 (for MP3 only), comments (for Ogg Vorbis), ...  
+     *
+     * @param stream could be File, URL or InputStream
+     * @param properties audio stream properties.
+     */
+    public void opened(Object stream, Map properties);
+
+    /**
+     * Progress callback while playing.
+     * 
+     * This method is called severals time per seconds while playing.
+     * properties map includes audio format features such as
+     * instant bitrate, microseconds position, current frame number, ... 
+     * 
+     * @param bytesread from encoded stream.
+     * @param microseconds elapsed (<b>reseted after a seek !</b>).
+     * @param pcmdata PCM samples.
+     * @param properties audio stream parameters.
+     */
+    public void progress(int bytesread, long microseconds, byte[] pcmdata, Map properties);
+
+    /**
+     * Notification callback for basicplayer events such as opened, eom ...
+     *  
+     * @param event
+     */
+    public void stateUpdated(BasicPlayerEvent event);
+
+    /**
+     * A handle to the BasicPlayer, plugins may control the player through
+     * the controller (play, stop, ...)
+     * @param controller : a handle to the player
+     */
+    public void setController(BasicController controller);
+}

--- a/basicplayer/src/test/java/javazoom/jlgui/basicplayer/BasicPlayerTest.java
+++ b/basicplayer/src/test/java/javazoom/jlgui/basicplayer/BasicPlayerTest.java
@@ -1,0 +1,169 @@
+/*
+ * BasicPlayerTest.
+ * 
+ * JavaZOOM : jlgui@javazoom.net
+ *            http://www.javazoom.net
+ *
+ *-----------------------------------------------------------------------
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as published
+ *   by the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *----------------------------------------------------------------------
+ */
+package javazoom.jlgui.basicplayer;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * This class implements a simple player based on BasicPlayer.
+ * BasicPlayer is a threaded class providing most features
+ * of a music player. BasicPlayer works with underlying JavaSound 
+ * SPIs to support multiple audio formats. Basically JavaSound supports
+ * WAV, AU, AIFF audio formats. Add MP3 SPI (from JavaZOOM) and Vorbis
+ * SPI( from JavaZOOM) in your CLASSPATH to play MP3 and Ogg Vorbis file.
+ */
+public class BasicPlayerTest implements BasicPlayerListener
+{
+	private PrintStream out = null;
+	
+	/**
+	 * Entry point.
+	 * @param args filename to play.
+	 */
+	public static void main(String[] args)
+	{
+		BasicPlayerTest test = new BasicPlayerTest();
+		test.play(args[0]);
+	}
+	
+	/**
+	 * Contructor.
+	 */
+	public BasicPlayerTest()
+	{
+		out = System.out;
+	}
+
+	public void play(String filename)
+	{
+		// Instantiate BasicPlayer.
+		BasicPlayer player = new BasicPlayer();
+		// BasicPlayer is a BasicController.
+		BasicController control = (BasicController) player;
+		// Register BasicPlayerTest to BasicPlayerListener events.
+		// It means that this object will be notified on BasicPlayer
+		// events such as : opened(...), progress(...), stateUpdated(...)
+		player.addBasicPlayerListener(this);
+
+		try
+		{			
+			// Open file, or URL or Stream (shoutcast) to play.
+			control.open(new File(filename));
+			// control.open(new URL("http://yourshoutcastserver.com:8000"));
+			
+			// Start playback in a thread.
+			control.play();
+			
+			// Set Volume (0 to 1.0).
+			// setGain should be called after control.play().
+			control.setGain(0.85);
+			
+			// Set Pan (-1.0 to 1.0).
+			// setPan should be called after control.play().
+			control.setPan(0.0);
+
+			// If you want to pause/resume/pause the played file then
+			// write a Swing player and just call control.pause(),
+			// control.resume() or control.stop().			
+			// Use control.seek(bytesToSkip) to seek file
+			// (i.e. fast forward and rewind). seek feature will
+			// work only if underlying JavaSound SPI implements
+			// skip(...). True for MP3SPI (JavaZOOM) and SUN SPI's
+			// (WAVE, AU, AIFF).
+			
+		}
+		catch (BasicPlayerException e)
+		{
+			e.printStackTrace();
+		}
+	}
+		
+	/**
+	 * Open callback, stream is ready to play.
+	 *
+	 * properties map includes audio format dependant features such as
+	 * bitrate, duration, frequency, channels, number of frames, vbr flag,
+	 * id3v2/id3v1 (for MP3 only), comments (for Ogg Vorbis), ... 
+	 *
+	 * @param stream could be File, URL or InputStream
+	 * @param properties audio stream properties.
+	 */
+	public void opened(Object stream, Map properties)
+	{
+		// Pay attention to properties. It's useful to get duration, 
+		// bitrate, channels, even tag such as ID3v2.
+		display("opened : "+properties.toString());		
+	}
+		
+	/**
+	 * Progress callback while playing.
+	 * 
+	 * This method is called severals time per seconds while playing.
+	 * properties map includes audio format features such as
+	 * instant bitrate, microseconds position, current frame number, ... 
+	 * 
+	 * @param bytesread from encoded stream.
+	 * @param microseconds elapsed (<b>reseted after a seek !</b>).
+	 * @param pcmdata PCM samples.
+	 * @param properties audio stream parameters.
+	 */
+	public void progress(int bytesread, long microseconds, byte[] pcmdata, Map properties)
+	{
+		// Pay attention to properties. It depends on underlying JavaSound SPI
+		// MP3SPI provides mp3.equalizer.
+		display("progress : "+properties.toString());
+	}
+	
+	/**
+	 * Notification callback for basicplayer events such as opened, eom ...
+	 *  
+	 * @param event
+	 */
+	public void stateUpdated(BasicPlayerEvent event)
+	{
+		// Notification of BasicPlayer states (opened, playing, end of media, ...)
+		display("stateUpdated : "+event.toString());
+		if (event.getCode()==BasicPlayerEvent.STOPPED)
+		{
+			System.exit(0);
+		}
+	}
+
+	/**
+	 * A handle to the BasicPlayer, plugins may control the player through
+	 * the controller (play, stop, ...)
+	 * @param controller : a handle to the player
+	 */	
+	public void setController(BasicController controller)
+	{
+		display("setController : "+controller);
+	}
+	
+	public void display(String msg)
+	{
+		if (out != null) out.println(msg);
+	}
+
+}

--- a/mp3spi/pom.xml
+++ b/mp3spi/pom.xml
@@ -50,7 +50,6 @@
                 <configuration>
                     <instructions>
                         <SPI-Provider>javax.sound.sampled.AudioSystem</SPI-Provider>
-                        <Export-Package>javazoom.spi</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/mp3spi/pom.xml
+++ b/mp3spi/pom.xml
@@ -50,6 +50,7 @@
                 <configuration>
                     <instructions>
                         <SPI-Provider>javax.sound.sampled.AudioSystem</SPI-Provider>
+                        <Export-Package>javazoom.spi</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>jorbis</module>
         <module>vorbisspi</module>
         <module>tritonus-all</module>
+        <module>basicplayer</module>
     </modules>
     <build>
         <pluginManagement>


### PR DESCRIPTION
I added the BasicPlayer module with the sources downloaded from http://www.javazoom.net/jlgui/api.html.

A direct link for the zip file is: http://www.javazoom.net/jlgui/sources/basicplayer3.0.zip

Please note the following modifications to the BasicPlayer source code were made while adding them to this module:
    1. Relocated src/javazoom to src/main/java/javazoom, and srctest/javazoom to src/test/java/javazoom. This was done to adhere to the standard maven file structure layout.
    2. Replaced dependency on commons-logging-api with dependency on slf4j-api. This was done because commons-logging-api is not a valid OSGi bundle while slf4j-api is. This required  changing BasicPlayer.java lines 48, 49, and 74 to use the slf4j api instead of commons logging.

Additional modifications to existing project code:
    1. Updated project aggregate pom to include the basicplayer module.
    2. Added <Export-Package>javazoom.spi</Export-Package> to the maven-bundle-plugin configuration instructions in the mp3spi module. BasicPlayer imports this package.
    3. Updated README.adoc with information pertaining to the BasicPlayer module.